### PR TITLE
Fix Sign-In form in English.

### DIFF
--- a/vj4/locale/en.yaml
+++ b/vj4/locale/en.yaml
@@ -1,5 +1,6 @@
 #English
 ---
+Remember me: Keep me in
 contest_create: Contest Create
 contest_main: Contest
 contest_status: Contest Status

--- a/vj4/ui/components/signin/signin_dialog.page.styl
+++ b/vj4/ui/components/signin/signin_dialog.page.styl
@@ -1,6 +1,6 @@
 $signin_form_width = 320px
 $signin_form_gap_v = 70px
-$signin_form_gap_h = 50px
+$signin_form_gap_h = 30px
 $signin_dialog_expand_v = 50px
 $signin_dialog_expand_h = 30px
 

--- a/vj4/ui/templates/components/login_dialog.html
+++ b/vj4/ui/templates/components/login_dialog.html
@@ -26,7 +26,7 @@
         </div></div>
         <div class="row"><div class="large-6 columns">
           <label class="checkbox">
-            <input type="checkbox" name="rememberme">{{ _('Remember me') }}
+            <input type="checkbox" name="rememberme">{{ _('Keep me in') }}
           </label>
         </div><div class="large-6 columns">
           <input type="submit" value="{{ _('Sign In') }}" class="expanded rounded primary button">

--- a/vj4/ui/templates/components/login_dialog.html
+++ b/vj4/ui/templates/components/login_dialog.html
@@ -26,7 +26,7 @@
         </div></div>
         <div class="row"><div class="large-6 columns">
           <label class="checkbox">
-            <input type="checkbox" name="rememberme">{{ _('Keep me in') }}
+            <input type="checkbox" name="rememberme">{{ _('Remember me') }}
           </label>
         </div><div class="large-6 columns">
           <input type="submit" value="{{ _('Sign In') }}" class="expanded rounded primary button">


### PR DESCRIPTION
* Reduced horizontal gap of the dialog from `50px` to `30px`
* Changed the English translation of *Remember me* into *Keep me in*, which is shorter, to avoid line wrapping.

**Before**
![image](https://cloud.githubusercontent.com/assets/2545261/17738618/97c9f696-64c4-11e6-8160-3ffdd7e53123.png)

**After**
![image](https://cloud.githubusercontent.com/assets/2545261/17739113/970ca954-64c6-11e6-85d8-4d301d78887c.png)