### PR TITLE
change "Courier New" to "Lucida Console"

### DIFF
--- a/vj4/ui/common/variables.inc.styl
+++ b/vj4/ui/common/variables.inc.styl
@@ -1,7 +1,7 @@
 // fonts
 $primary-font-family = "Open Sans", "Seravek", "Segoe UI", "Verdana", "PingFang SC", "Hiragino Sans GB", "Lantinghei SC", "Microsoft Yahei", "WenQuanYi Micro Hei", "sans"
 $header-font-family = "Open Sans", "Seravek", "Segoe UI", "Verdana", "PingFang SC", "Lantinghei SC", "Microsoft Yahei", "Hiragino Sans GB", "Microsoft Sans Serif", "WenQuanYi Micro Hei", "sans-serif"
-$code-font-family = "monaco", "Source Code Pro", "Consolas", "Courier New", "monospace"
+$code-font-family = "monaco", "Source Code Pro", "Consolas", "Lucida Console", "monospace"
 
 // primary palette
 $default-color = #ddd


### PR DESCRIPTION
Courier New is often worse than monospace. Changing to Lucida Console. See also http://www.cssfontstack.com/Monaco.