### PR TITLE
Create release only on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ deploy:
   skip_cleanup: true
   on:
     repo: vijos/vj4
-    branch: master
+    tags: true
     python: 3.5


### PR DESCRIPTION
This would reduce noise (#241) but require manual tagging on server update. Let's try this out?

This is the only supported way to create automated releases using travis:
https://docs.travis-ci.com/user/deployment/releases/
(on branch was a hacky setting)