### PR TITLE
Fix static-manifest generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7297,12 +7297,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "mutexify": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npm.taobao.org/mutexify/download/mutexify-1.2.0.tgz",
-      "integrity": "sha1-RVl5daKwNfVtz2H/FcyNc8KOdjk=",
-      "dev": true
-    },
     "nan": {
       "version": "2.6.2",
       "resolved": "http://registry.npm.taobao.org/nan/download/nan-2.6.2.tgz",
@@ -11798,32 +11792,6 @@
           "requires": {
             "global": "4.3.2",
             "setimmediate": "1.0.5"
-          }
-        }
-      }
-    },
-    "webpack-manifest-plugin": {
-      "version": "1.3.0",
-      "resolved": "http://registry.npm.taobao.org/webpack-manifest-plugin/download/webpack-manifest-plugin-1.3.0.tgz",
-      "integrity": "sha1-CFJtXluPPiBMmSLcGvfz9H2dVEg=",
-      "dev": true,
-      "requires": {
-        "fs-extra": "0.30.0",
-        "lodash": "4.17.4",
-        "mutexify": "1.2.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "http://registry.npm.taobao.org/fs-extra/download/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "stylus-loader": "^3.0.1",
     "through2": "^2.0.3",
     "webpack": "^3.5.3",
-    "webpack-manifest-plugin": "^1.3.0",
     "yargs": "^8.0.2"
   },
   "dependencies": {

--- a/scripts/build/config/webpack.js
+++ b/scripts/build/config/webpack.js
@@ -11,7 +11,6 @@ import FriendlyErrorsPlugin from 'friendly-errors-webpack-plugin';
 import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
-import ManifestPlugin from 'webpack-manifest-plugin';
 
 const extractProjectCSS = new ExtractTextPlugin({ filename: 'vj4.css?[sha1:contenthash:hex:10]', allChunks: true });
 const extractVendorCSS = new ExtractTextPlugin({ filename: 'vendors.css?[sha1:contenthash:hex:10]', allChunks: true });

--- a/scripts/build/config/webpack.js
+++ b/scripts/build/config/webpack.js
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import root from '../utils/root.js';
 import mapWebpackUrlPrefix from '../utils/mapWebpackUrlPrefix.js';
 import DummyOutputPlugin from '../plugins/webpackDummyOutputPlugin.js';
+import StaticManifestPlugin from '../plugins/webpackStaticManifestPlugin.js';
 import FriendlyErrorsPlugin from 'friendly-errors-webpack-plugin';
 import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
@@ -273,11 +274,6 @@ export default function (env = {}) {
         : new webpack.NamedModulesPlugin()
         ,
 
-      // Output asset hashes
-      new ManifestPlugin({
-        fileName: 'static-manifest.json',
-      }),
-
       new webpack.LoaderOptionsPlugin({
         options: {
           context: root(),
@@ -287,6 +283,14 @@ export default function (env = {}) {
         },
       }),
 
+      // Finally, output asset hashes
+      new StaticManifestPlugin({
+        fileName: 'static-manifest.json',
+        ignore: [
+          'img/emoji/',
+          'katex/',
+        ],
+      }),
     ],
   };
 

--- a/scripts/build/plugins/webpackStaticManifestPlugin.js
+++ b/scripts/build/plugins/webpackStaticManifestPlugin.js
@@ -1,0 +1,49 @@
+const _ = require('lodash');
+const path = require('path');
+const crypto = require('crypto');
+
+export default class StaticManifestPlugin {
+  constructor({ fileName, ignore }) {
+    this.fileName = fileName;
+    this.ignore = ignore;
+  }
+  apply(compiler) {
+    compiler.plugin('emit', (compilation, callback) => {
+      const stats = compilation.getStats().toJson();
+      const manifest = _(stats.assets)
+        .map((asset) => {
+          const name = asset.name;
+          // Skip files listed in ignore
+          if (_.some(this.ignore, ignorePattern => name.indexOf(ignorePattern) > -1)) {
+            return null;
+          }
+          // Skip calculating hash for names like ?xxxx
+          if (name.indexOf('?') > -1) {
+            return [
+              name.replace(/\?[\s\S]*/, ''),  // origin name
+              name,                           // name with hash
+            ];
+          }
+          // We need to calculate hash for the remaining files.
+          const source = compilation.assets[asset.name].source();
+          const shasum = crypto.createHash('sha1');
+          shasum.update(source);
+          const hash = shasum.digest('hex').substr(0, 10);
+          return [
+            name,               // origin name
+            `${name}?${hash}`,  // name with hash
+          ];
+        })
+        .filter()
+        .orderBy(['0'])
+        .fromPairs()
+        .value();
+      const json = JSON.stringify(manifest, null, 2);
+      compilation.assets[this.fileName] = {
+        source: () => json,
+        size: () => json.length,
+      };
+      callback();
+    });
+  }
+}

--- a/scripts/build/plugins/webpackStaticManifestPlugin.js
+++ b/scripts/build/plugins/webpackStaticManifestPlugin.js
@@ -9,7 +9,6 @@ export default class StaticManifestPlugin {
   }
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
-
       const stats = compilation.getStats().toJson();
       const manifest = _(stats.assets)
         .map((asset) => {

--- a/scripts/build/plugins/webpackStaticManifestPlugin.js
+++ b/scripts/build/plugins/webpackStaticManifestPlugin.js
@@ -9,6 +9,7 @@ export default class StaticManifestPlugin {
   }
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
+
       const stats = compilation.getStats().toJson();
       const manifest = _(stats.assets)
         .map((asset) => {


### PR DESCRIPTION
Now `static-manifest.json` contains more files, which is missing previously. For example, `vendors.css`, `locale/zh_CN.js`, etc.

Fix https://github.com/vijos/vj4/issues/281