### PR TITLE
Delete pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,0 @@
-[FORMAT]
-indent-string='  '
-indent-after-paren=4
-
-[MESSAGES CONTROL]
-disable=C0111,C0301


### PR DESCRIPTION
`pylintrc` is not necessary.