### PR TITLE
kill per-user rate limit

### DIFF
--- a/vj4/handler/contest.py
+++ b/vj4/handler/contest.py
@@ -300,7 +300,7 @@ class ContestDetailProblemSubmitHandler(ContestMixin, base.Handler):
   @base.sanitize
   async def post(self, *,
                  tid: objectid.ObjectId, pid: document.convert_doc_id, lang: str, code: str):
-    await opcount.inc(**opcount.OPS['run_code'], ident=opcount.PREFIX_USER + str(self.user['_id']))
+    # TODO(iceboy): rate limit base on ip.
     tdoc, pdoc = await asyncio.gather(contest.get(self.domain_id, tid),
                                       problem.get(self.domain_id, pid))
     tsdoc = await contest.get_status(self.domain_id, tdoc['doc_id'], self.user['_id'])

--- a/vj4/handler/problem.py
+++ b/vj4/handler/problem.py
@@ -246,7 +246,7 @@ class ProblemSubmitHandler(base.Handler):
   @base.require_csrf_token
   @base.sanitize
   async def post(self, *, pid: document.convert_doc_id, lang: str, code: str):
-    await opcount.inc(**opcount.OPS['run_code'], ident=opcount.PREFIX_USER + str(self.user['_id']))
+    # TODO(iceboy): rate limit base on ip.
     # TODO(twd2): check status, eg. test, hidden problem, ...
     pdoc = await problem.get(self.domain_id, pid)
     if pdoc.get('hidden', False):
@@ -265,7 +265,7 @@ class ProblemPretestHandler(base.Handler):
   @base.sanitize
   async def post(self, *, pid: document.convert_doc_id, lang: str, code: str,
                  data_input: str, data_output: str):
-    await opcount.inc(**opcount.OPS['run_code'], ident=opcount.PREFIX_USER + str(self.user['_id']))
+    # TODO(iceboy): rate limit base on ip.
     pdoc = await problem.get(self.domain_id, pid)
     # don't need to check hidden status
     # create zip file, TODO(twd2): check file size

--- a/vj4/model/opcount.py
+++ b/vj4/model/opcount.py
@@ -47,21 +47,6 @@ async def inc(op: str, ident: str, period_secs: int, max_operations: int, operat
 
 
 @argmethod.wrap
-async def force_inc(op: str, ident: str, period_secs: int, max_operations: int, operations: int=1):
-  coll = db.coll('opcount')
-  cur_time = int(time.time())
-  begin_at = datetime.datetime.utcfromtimestamp(cur_time - cur_time % period_secs)
-  expire_at = begin_at + datetime.timedelta(seconds=period_secs)
-  doc = await coll.find_one_and_update(filter={'ident': ident,
-                                               'begin_at': begin_at,
-                                               'expire_at': expire_at},
-                                       update={'$inc': {op: operations}},
-                                       upsert=True,
-                                       return_document=ReturnDocument.AFTER)
-  return doc
-
-
-@argmethod.wrap
 async def get(op: str, ident: str, period_secs: int, max_operations: int):
   coll = db.coll('opcount')
   cur_time = int(time.time())

--- a/vj4/model/opcount.py
+++ b/vj4/model/opcount.py
@@ -9,7 +9,6 @@ from vj4 import error
 from vj4.util import argmethod
 
 PREFIX_IP = 'ip-'
-PREFIX_USER = 'user-'
 
 OPS = {
   'contest_code': {
@@ -22,11 +21,6 @@ OPS = {
     'period_secs': 3600,
     'max_operations': 60
   },
-  'run_code': {
-    'op': 'run_code',
-    'period_secs': 60,
-    'max_operations': 15000
-  }
 }
 
 PERIOD_REGISTER = 3600


### PR DESCRIPTION
per-user rate limit is not useful at all - attacker could register a lot of users (even in a very slow rate like 1 user per day) to bypass this limit.

next plans:

remove resource usage reporting on compile error in jd4 (#376)
use decorator for all rate limits
add per-ip rate limit to resource-consuming operations

this PR will be merged even without reviewer approval.