### PR TITLE
add c# support (fixes #389)

### DIFF
--- a/vj4/ui/components/highlighter/prismjs.js
+++ b/vj4/ui/components/highlighter/prismjs.js
@@ -21,6 +21,7 @@ import 'prismjs/components/prism-haskell';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-go';
 import 'prismjs/components/prism-ruby';
+import 'prismjs/components/prism-csharp';
 import 'prismjs/plugins/toolbar/prism-toolbar';
 import 'prismjs/plugins/line-numbers/prism-line-numbers';
 

--- a/vj4/ui/constant/language.js
+++ b/vj4/ui/constant/language.js
@@ -3,6 +3,7 @@ import attachObjectMeta from './util/objectMeta';
 export const LANG_TEXTS = {
   c: 'C',
   cc: 'C++',
+  cs: 'C#',
   pas: 'Pascal',
   java: 'Java',
   py: 'Python',
@@ -18,6 +19,7 @@ export const LANG_TEXTS = {
 export const LANG_HIGHLIGHT_ID = {
   c: 'c',
   cc: 'cpp',
+  cs: 'csharp',
   pas: 'pascal',
   java: 'java',
   py: 'python',
@@ -33,6 +35,7 @@ export const LANG_HIGHLIGHT_ID = {
 export const LANG_CODEMIRROR_MODES = {
   c: 'text/x-csrc',
   cc: 'text/x-c++src',
+  cs: 'text/x-csharp',
   pas: 'text/x-pascal',
   java: 'text/x-java',
   py: 'text/x-python',


### PR DESCRIPTION
note that codemirror supports c# in 'clike', so that the following files are not modified:
vj4/ui/components/cmeditor/vjcmeditor.js
vj4/ui/components/scratchpad/ScratchpadEditorContainer.js