### PR TITLE
fix build break, downgrading webpack & aiohttp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,12 +2612,6 @@
         "isarray": "1.0.0"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "http://registry.npm.taobao.org/dom-walk/download/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
-    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "http://registry.npm.taobao.org/domain-browser/download/domain-browser-1.1.7.tgz",
@@ -4467,14 +4461,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4483,6 +4469,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4823,24 +4817,6 @@
       "dev": true,
       "requires": {
         "find-index": "0.1.1"
-      }
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "http://registry.npm.taobao.org/global/download/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
-      "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "http://registry.npm.taobao.org/process/download/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-          "dev": true
-        }
       }
     },
     "global-modules": {
@@ -7116,15 +7092,6 @@
       "resolved": "http://registry.npm.taobao.org/mimic-fn/download/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "http://registry.npm.taobao.org/min-document/download/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "0.1.1"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -10643,15 +10610,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/string-length/download/string-length-1.0.1.tgz",
@@ -10699,6 +10657,15 @@
       "resolved": "http://registry.npm.taobao.org/string.prototype.codepointat/download/string.prototype.codepointat-0.2.0.tgz",
       "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -11599,15 +11566,15 @@
       }
     },
     "webpack": {
-      "version": "3.5.4",
-      "resolved": "http://registry.npm.taobao.org/webpack/download/webpack-3.5.4.tgz",
-      "integrity": "sha1-VYPrJj7Se3i1vRe/37DrGxzRv4E=",
+      "version": "3.2.0",
+      "resolved": "http://registry.npm.taobao.org/webpack/download/webpack-3.2.0.tgz",
+      "integrity": "sha1-iwyuDhqf12v78Oq2Gowq2oSMMS8=",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.2.2",
-        "ajv-keywords": "2.1.0",
+        "ajv-keywords": "2.1.1",
         "async": "2.5.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -11618,20 +11585,35 @@
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
+        "node-libs-browser": "2.1.0",
         "source-map": "0.5.6",
-        "supports-color": "4.2.1",
+        "supports-color": "3.2.3",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
         "webpack-sources": "1.0.1",
-        "yargs": "8.0.2"
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "http://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "resolved": "http://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz",
+          "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+          "dev": true,
+          "requires": {
+            "pako": "1.0.6"
+          }
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "enhanced-resolve": {
@@ -11646,6 +11628,50 @@
             "tapable": "0.2.8"
           }
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz",
+          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/load-json-file/download/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
         "memory-fs": {
           "version": "0.4.1",
           "resolved": "http://registry.npm.taobao.org/memory-fs/download/memory-fs-0.4.1.tgz",
@@ -11657,21 +11683,21 @@
           }
         },
         "node-libs-browser": {
-          "version": "2.0.0",
-          "resolved": "http://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.0.0.tgz",
-          "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.1.0.tgz",
+          "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
           "dev": true,
           "requires": {
             "assert": "1.4.1",
-            "browserify-zlib": "0.1.4",
+            "browserify-zlib": "0.2.0",
             "buffer": "4.9.1",
             "console-browserify": "1.1.0",
             "constants-browserify": "1.0.0",
             "crypto-browserify": "3.11.1",
             "domain-browser": "1.1.7",
             "events": "1.1.1",
-            "https-browserify": "0.0.1",
-            "os-browserify": "0.2.1",
+            "https-browserify": "1.0.0",
+            "os-browserify": "0.3.0",
             "path-browserify": "0.0.0",
             "process": "0.11.10",
             "punycode": "1.4.1",
@@ -11679,19 +11705,95 @@
             "readable-stream": "2.3.3",
             "stream-browserify": "2.0.1",
             "stream-http": "2.7.2",
-            "string_decoder": "0.10.31",
-            "timers-browserify": "2.0.3",
+            "string_decoder": "1.0.3",
+            "timers-browserify": "2.0.10",
             "tty-browserify": "0.0.0",
             "url": "0.11.0",
             "util": "0.10.3",
             "vm-browserify": "0.0.4"
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+        "os-browserify": {
+          "version": "0.3.0",
+          "resolved": "http://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz",
+          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
           "dev": true
+        },
+        "pako": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npm.taobao.org/pako/download/pako-1.0.6.tgz",
+          "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/read-pkg/download/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/strip-bom/download/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "tapable": {
           "version": "0.2.8",
@@ -11700,13 +11802,48 @@
           "dev": true
         },
         "timers-browserify": {
-          "version": "2.0.3",
-          "resolved": "http://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.3.tgz",
-          "integrity": "sha1-Qf0L3JJqX+7cM6F6jh99SRkl9/w=",
+          "version": "2.0.10",
+          "resolved": "http://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.10.tgz",
+          "integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
           "dev": true,
           "requires": {
-            "global": "4.3.2",
             "setimmediate": "1.0.5"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/which-module/download/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "http://registry.npm.taobao.org/yargs/download/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "http://registry.npm.taobao.org/yargs-parser/download/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "through2": "^2.0.3",
-    "webpack": "^3.5.4",
+    "webpack": "^3.2.0",
     "yargs": "^8.0.2"
   },
   "dependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.0.7
+aiohttp>=2.0.7,<3.0.0
 jinja2>=2.9.0
 sockjs>=0.6.0
 hoedown


### PR DESCRIPTION
A problem of webpack (possibly https://github.com/webpack/webpack/issues/5408) causes errors when running `npm run build:production`

aiohttp 3.0+ causes a missing member in handler and leads to HTTP 500 error.

Downgrading webpack to 3.2.0 and limit aiohttp to <3.0.0 fixes the problem.