### PR TITLE
fix: regex matching of email address

### DIFF
--- a/vj4/util/validator.py
+++ b/vj4/util/validator.py
@@ -6,7 +6,7 @@ from vj4 import error
 
 UID_RE = re.compile(r'-?\d+')
 UNAME_RE = re.compile(r'[^\s\u3000](.{,254}[^\s\u3000])?')
-MAIL_RE = re.compile(r'\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*')
+MAIL_RE = re.compile(r'\w+([-+.\w]+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*')
 # TODO(twd2): unicode char
 DOMAIN_ID_RE = re.compile(r'[_A-Za-z][_0-9A-Za-z]{3,255}')
 ID_RE = re.compile(r'[^\\/\s\u3000]([^\\/\n\r]*[^\\/\s\u3000])?')

--- a/vj4/util/validator.py
+++ b/vj4/util/validator.py
@@ -6,7 +6,7 @@ from vj4 import error
 
 UID_RE = re.compile(r'-?\d+')
 UNAME_RE = re.compile(r'[^\s\u3000](.{,254}[^\s\u3000])?')
-MAIL_RE = re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+')
+MAIL_RE = re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-])+')
 # TODO(twd2): unicode char
 DOMAIN_ID_RE = re.compile(r'[_A-Za-z][_0-9A-Za-z]{3,255}')
 ID_RE = re.compile(r'[^\\/\s\u3000]([^\\/\n\r]*[^\\/\s\u3000])?')

--- a/vj4/util/validator.py
+++ b/vj4/util/validator.py
@@ -6,7 +6,7 @@ from vj4 import error
 
 UID_RE = re.compile(r'-?\d+')
 UNAME_RE = re.compile(r'[^\s\u3000](.{,254}[^\s\u3000])?')
-MAIL_RE = re.compile(r'\w+([-+.\w]+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*')
+MAIL_RE = re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+')
 # TODO(twd2): unicode char
 DOMAIN_ID_RE = re.compile(r'[_A-Za-z][_0-9A-Za-z]{3,255}')
 ID_RE = re.compile(r'[^\\/\s\u3000]([^\\/\n\r]*[^\\/\s\u3000])?')

--- a/vj4/util/validator.py
+++ b/vj4/util/validator.py
@@ -6,7 +6,7 @@ from vj4 import error
 
 UID_RE = re.compile(r'-?\d+')
 UNAME_RE = re.compile(r'[^\s\u3000](.{,254}[^\s\u3000])?')
-MAIL_RE = re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-])+')
+MAIL_RE = re.compile(r'[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+')
 # TODO(twd2): unicode char
 DOMAIN_ID_RE = re.compile(r'[_A-Za-z][_0-9A-Za-z]{3,255}')
 ID_RE = re.compile(r'[^\\/\s\u3000]([^\\/\n\r]*[^\\/\s\u3000])?')


### PR DESCRIPTION
When matching emails with special characters before "@", the regex fails because it assume the last character is "\w", but it is not always the case.

```python3
import re
MAIL_RE = re.compile(r'\w+([-+.\w]+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*')
MAIL_RE_WRONG = re.compile(r'\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*')

bool(MAIL_RE.fullmatch('foo-.-@exmaple.com')) == True
bool(MAIL_RE_WRONG.fullmatch('foo-.-@exmaple.com')) == False
````

(This is the real case we met)