### PR TITLE
Read args from env as an alternative, Dockerize vj4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+data/
+docker-compose.yml
+Dockerfile

--- a/.env.example
+++ b/.env.example
@@ -13,17 +13,42 @@
 # --listen
 # Server listening address
 #===================================
-# Default: "http://127.0.0.1:8888"
+# Default: http://127.0.0.1:8888
 # Example:
-#   "unix:/var/run/vj4.sock"
-#   "http://0.0.0.0:80"
+#   unix:/var/run/vj4.sock
+#   http://0.0.0.0:80
 #
 # ./data/run is
 #   /var/run/vj4 in the container
 # You should expose ports manually
 #   if you are using port listening
 #===================================
-VJ_LISTEN="unix:/var/run/vj4/web.sock"
+VJ_LISTEN=unix:/var/run/vj4/web.sock
+#===================================
+# --listen-owner
+# Owner of the socket when server
+#   is listening to a unix socket.
+#===================================
+# Default: www-data
+#===================================
+VJ_LISTEN_OWNER=www-data
+#===================================
+# --listen-group
+# Group of the socket when server
+#   is listening to a unix socket.
+#===================================
+# Default: www-data
+#===================================
+VJ_LISTEN_GROUP=www-data
+#===================================
+# --listen-mode
+# File mode of the socket when
+#   server is listening to a
+#   unix socket.
+#===================================
+# Default: 660
+#===================================
+VJ_LISTEN_MODE=660
 
 #===================================
 # --prefork
@@ -37,67 +62,65 @@ VJ_LISTEN="unix:/var/run/vj4/web.sock"
 # --db-host
 # MongoDB Host
 #===================================
-# Default: "localhost"
+# Default: localhost
 # Use "mongodb" if you are using
 #   default docker-compose.yml
 #===================================
-VJ_DB_HOST="mongodb"
+VJ_DB_HOST=mongodb
 #===================================
 # --db-name
 # Database name in MongoDB
 #===================================
-# Default: "test"
+# Default: test
 #===================================
-VJ_DB_NAME="vijos4"
+VJ_DB_NAME=vijos4
 
 #===================================
 # --mq-host
 # AMQP Host
 #===================================
-# Default: "localhost"
+# Default: localhost
 # Use "rabbitmq" if you are using
 #   default docker-compose.yml
 #===================================
-VJ_MQ_HOST="rabbitmq"
+VJ_MQ_HOST=rabbitmq
 #===================================
 # --mq-vhost
 # AMQP vhost
 #===================================
-# Default: "/"
+# Default: /
 #===================================
-# VJ_MQ_VHOST="/"
+# VJ_MQ_VHOST=/
 
 #===================================
 # --ip-header
 # HTTP header which is used by proxy
 #   to pass real user IP
 #===================================
-# Default: ""
-#===================================
-# VJ_IP_HEADER="X-Real-IP"
+# VJ_IP_HEADER=X-Real-IP
 
 #===================================
 # --url-prefix
 # URL prefix
 #===================================
-# Default: "https://vijos.org"
+# Default: https://vijos.org
 #===================================
-# VJ_URL_PREFIX="http://127.0.0.1"
+# VJ_URL_PREFIX=http://127.0.0.1
 
 #===================================
 # --cdn-prefix
 # CDN prefix
 #===================================
-# Default: "/"
+# Default: /
 #===================================
-# VJ_CDN_PREFIX="/"
+# VJ_CDN_PREFIX=/
 
 #===================================
 # --default-locale
 #===================================
-# Default: "zh_CN"
+# Default: zh_CN
 #===================================
-# VJ_DEFAULT_LOCALE="zh_CN"
+# VJ_DEFAULT_LOCALE=zh_CN
 
 
 #===================================

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,150 @@
+# # # # # # # # # # # # # # # # # # #
+#    Vijos Environment Variables    #
+#                                   #
+#  Just replace `_` to `-` in       #
+#  command-line parameter name,     #
+#  uppercase them and add a prefix  #
+#  `VJ_`.                           #
+#                                   #
+#       It's useful in Docker!      #
+# # # # # # # # # # # # # # # # # # #
+
+#===================================
+# --listen
+# Server listening address
+#===================================
+# Default: "http://127.0.0.1:8888"
+# Example:
+#   "unix:/var/run/vj4.sock"
+#   "http://0.0.0.0:80"
+#
+# ./data/run is
+#   /var/run/vj4 in the container
+# You should expose ports manually
+#   if you are using port listening
+#===================================
+VJ_LISTEN="unix:/var/run/vj4/web.sock"
+
+#===================================
+# --prefork
+# Number of prefork workers
+#===================================
+# Default: 1
+#===================================
+# VJ_PREFORK=4
+
+#===================================
+# --db-host
+# MongoDB Host
+#===================================
+# Default: "localhost"
+# Use "mongodb" if you are using
+#   default docker-compose.yml
+#===================================
+VJ_DB_HOST="mongodb"
+#===================================
+# --db-name
+# Database name in MongoDB
+#===================================
+# Default: "test"
+#===================================
+VJ_DB_NAME="vijos4"
+
+#===================================
+# --mq-host
+# AMQP Host
+#===================================
+# Default: "localhost"
+# Use "rabbitmq" if you are using
+#   default docker-compose.yml
+#===================================
+VJ_MQ_HOST="rabbitmq"
+#===================================
+# --mq-vhost
+# AMQP vhost
+#===================================
+# Default: "/"
+#===================================
+# VJ_MQ_VHOST="/"
+
+#===================================
+# --ip-header
+# HTTP header which is used by proxy
+#   to pass real user IP
+#===================================
+# Default: ""
+#===================================
+# VJ_IP_HEADER="X-Real-IP"
+
+#===================================
+# --url-prefix
+# URL prefix
+#===================================
+# Default: "https://vijos.org"
+#===================================
+# VJ_URL_PREFIX="http://127.0.0.1"
+
+#===================================
+# --cdn-prefix
+# CDN prefix
+#===================================
+# Default: "/"
+#===================================
+# VJ_CDN_PREFIX="/"
+
+#===================================
+# --default-locale
+#===================================
+# Default: "zh_CN"
+#===================================
+# VJ_DEFAULT_LOCALE="zh_CN"
+
+
+#===================================
+# --smallcache-max-entries
+# Maximum number of
+#   entries in smallcache.
+#===================================
+# Default: 64
+#===================================
+# VJ_SMALLCACHE_MAX_ENTRIES=64
+#===================================
+# --unsaved-session-expire-seconds
+# Expire time for
+#   unsaved session, in seconds.
+#===================================
+# Default: 43200
+#===================================
+# VJ_UNSAVED_SESSION_EXPIRE_SECONDS=43200
+#===================================
+# --saved-session-expire-seconds
+# Expire time for
+#   saved session, in seconds.
+#===================================
+# Default: 2592000
+#===================================
+# VJ_SAVED_SESSION_EXPIRE_SECONDS=2592000
+#===================================
+# --registration-token-expire-seconds
+# Expire time for
+#   registration token, in seconds.
+#===================================
+# Default: 86400
+#===================================
+# VJ_REGISTRATION_TOKEN_EXPIRE_SECONDS=86400
+#===================================
+# --lostpass-token-expire-seconds
+# Expire time for
+#   lostpass token, in seconds.
+#===================================
+# Default: 3600
+#===================================
+# VJ_LOSTPASS_TOKEN_EXPIRE_SECONDS=3600
+#===================================
+# --changemail-token-expire-seconds
+# Expire time for
+#   changemail token, in seconds.
+#===================================
+# Default: 3600
+#===================================
+# VJ_CHANGEMAIL_TOKEN_EXPIRE_SECONDS=3600

--- a/.env.example
+++ b/.env.example
@@ -171,3 +171,12 @@ VJ_MQ_HOST=rabbitmq
 # Default: 3600
 #===================================
 # VJ_CHANGEMAIL_TOKEN_EXPIRE_SECONDS=3600
+
+#===================================
+# VJ_CMDLINE_FLAGS
+# This is only for setting boolean
+#   flags like
+#   `--pretty` `--no-debug`.
+# Split with spaces.
+#===================================
+# VJ_CMDLINE_FLAGS=--no-syslog --static

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ vj4/ui/static/locale
 .webpackStats.json
 
 !.gitkeep
+
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ vj4/ui/static/locale
 !.gitkeep
 
 data/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# stage-node generates front-end files
+FROM node:8-stretch AS stage-node
+RUN mkdir -p /app/src
+ADD . /app/src/
+WORKDIR /app/src
+RUN npm install
+RUN npm run build:production
+
+# main
+FROM python:3.6-stretch
+COPY --from=stage-node /app/src /app/src
+WORKDIR /app/src
+
+RUN apt-get update \
+    && apt-get install -y \
+        libmaxminddb0 mmdb-bin libmaxminddb-dev \
+    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install -r requirements.txt
+RUN curl "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > GeoLite2-City.mmdb
+
+ENTRYPOINT [ "python3", "-m" ]
+EXPOSE 80
+
+CMD [ "vj4.server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /app/src
 ADD . /app/src/
 WORKDIR /app/src
 RUN npm install \
-	&& npm run build:production
+    && npm run build:production
 
 # main
 FROM python:3.6-stretch
@@ -15,11 +15,10 @@ RUN apt-get update \
     && apt-get install -y \
         libmaxminddb0 mmdb-bin libmaxminddb-dev \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
-	&& python3 -m pip install -r requirements.txt \
-	&& curl "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > GeoLite2-City.mmdb
+    && python3 -m pip install -r requirements.txt \
+    && curl "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > GeoLite2-City.mmdb
 
 ENTRYPOINT [ "python3", "-m" ]
 EXPOSE 80
 
-USER www-data
 CMD [ "vj4.server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:8-stretch AS stage-node
 RUN mkdir -p /app/src
 ADD . /app/src/
 WORKDIR /app/src
-RUN npm install
-RUN npm run build:production
+RUN npm install \
+	&& npm run build:production
 
 # main
 FROM python:3.6-stretch
@@ -14,11 +14,12 @@ WORKDIR /app/src
 RUN apt-get update \
     && apt-get install -y \
         libmaxminddb0 mmdb-bin libmaxminddb-dev \
-    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN python3 -m pip install -r requirements.txt
-RUN curl "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > GeoLite2-City.mmdb
+    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
+	&& python3 -m pip install -r requirements.txt \
+	&& curl "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz" | gunzip -c > GeoLite2-City.mmdb
 
 ENTRYPOINT [ "python3", "-m" ]
 EXPOSE 80
 
+USER www-data
 CMD [ "vj4.server" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  web:
+    build: .
+    image: vijos/vj4
+    restart: always
+    # set arguments for vj4.server below
+    command: vj4.server --db-host=mongodb --mq-host=rabbitmq --listen=http://0.0.0.0:80
+    ports:
+      - "80:80"
+    links:
+      - mongodb
+      - rabbitmq
+    depends_on:
+      - rabbitmq
+      - mongodb
+
+  rabbitmq:
+    restart: always
+    image: rabbitmq:latest
+    volumes:
+      - ./data/rabbitmq:/var/lib/rabbitmq
+  mongodb:
+    restart: always
+    image: mongo:latest
+    volumes:
+      - ./data/mongodb:/data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     build: .
     image: vijos/vj4
     restart: always
-    # set arguments for vj4.server below
-    command: vj4.server --db-host=mongodb --mq-host=rabbitmq --listen=http://0.0.0.0:80
-    ports:
-      - "80:80"
+    command: vj4.server
+    env_file: .env
+    volumes:
+        - ./data/run:/var/run/vj4
     links:
       - mongodb
       - rabbitmq

--- a/vj4/server.py
+++ b/vj4/server.py
@@ -2,6 +2,7 @@ import atexit
 import coloredlogs
 import logging
 import os
+import shutil
 import signal
 import socket
 import sys
@@ -15,6 +16,9 @@ from vj4.util import options
 options.define('listen', default='http://127.0.0.1:8888', help='Server listening address.')
 options.define('prefork', default=1, help='Number of prefork workers.')
 options.define('syslog', default=False, help='Use syslog instead of stderr for logging.')
+options.define('listen_owner', default='www-data', help='Owner of the socket when server is listening to a unix socket.')
+options.define('listen_group', default='www-data', help='Group of the socket when server is listening to a unix socket.')
+options.define('listen_mode', default='660', help='File mode of the socket when server is listening to a unix socket.')
 
 _logger = logging.getLogger(__name__)
 
@@ -41,6 +45,8 @@ def main():
     except FileNotFoundError:
       pass
     sock.bind(url.path)
+    shutil.chown(url.path, options.listen_owner, options.listen_group)
+    os.chmod(url.path, int(options.listen_mode, 8))
   else:
     _logger.error('Invalid listening scheme %s', url.scheme)
     return 1

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -25,7 +25,7 @@ class Options(object):
 
       for k,v in os.environ.items(): # using environments start with `VJ_` as arguments
         if k.startswith("VJ_"):
-          args_to_parse.append(f"--{k[3:].lower().replace('_','-')}")
+          args_to_parse.append('--' + k[3:].lower().replace('_','-'))
           args_to_parse.append(v) # append: use environments first
 
       self._parser.parse_known_args(args=args_to_parse, namespace=self._namespace)

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -23,15 +23,13 @@ class Options(object):
     if self._dirty:
       args_to_parse = []
       for k, v in os.environ.items(): # using environments start with `VJ_` as arguments
-        if k.startswith("VJ_"):
+        if k.startswith('VJ_'):
           if k == 'VJ_CMDLINE_FLAGS': # for setting bool flags like `--debug` or `--no-pretty`
-            for v in v.split(' '):
-              args_to_parse.append(v)
+            args_to_parse.extend(v.split())
           else:
             args_to_parse.append('--' + k[3:].lower().replace('_','-'))
             args_to_parse.append(v)
-      for v in sys.argv[1:]:
-        args_to_parse.append(v) # cmdline args can override one in env
+      args_to_parse.extend(sys.argv[1:]) # cmdline args can override one in env
 
       self._parser.parse_known_args(args=args_to_parse, namespace=self._namespace)
       self._dirty = False

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -1,7 +1,7 @@
 """A command line parsing module which mimics tornado's interface."""
 import argparse
 import sys
-
+import os
 
 class Options(object):
   _parser = argparse.ArgumentParser()
@@ -21,7 +21,14 @@ class Options(object):
 
   def __getattr__(self, item):
     if self._dirty:
-      self._parser.parse_known_args(args=sys.argv[1:], namespace=self._namespace)
+      args_to_parse = sys.argv[1:]
+
+      for k,v in os.environ.items(): # hack for using environments start with `VJ_` as arguments
+        if k.startswith("VJ_"):
+          args_to_parse.append(f"--{k[3:].lower().replace('_','-')}")
+          args_to_parse.append(v) # append: use environments first
+
+      self._parser.parse_known_args(args=args_to_parse, namespace=self._namespace)
       self._dirty = False
     return getattr(self._namespace, item)
 

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -21,12 +21,13 @@ class Options(object):
 
   def __getattr__(self, item):
     if self._dirty:
-      args_to_parse = sys.argv[1:]
-
+      args_to_parse = []
       for k,v in os.environ.items(): # using environments start with `VJ_` as arguments
         if k.startswith("VJ_"):
           args_to_parse.append('--' + k[3:].lower().replace('_','-'))
-          args_to_parse.append(v) # append: use environments first
+          args_to_parse.append(v)
+      for v in sys.argv[1:]:
+        args_to_parse.append(v) # cmdline args can override one in env
 
       self._parser.parse_known_args(args=args_to_parse, namespace=self._namespace)
       self._dirty = False

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -22,10 +22,14 @@ class Options(object):
   def __getattr__(self, item):
     if self._dirty:
       args_to_parse = []
-      for k,v in os.environ.items(): # using environments start with `VJ_` as arguments
+      for k, v in os.environ.items(): # using environments start with `VJ_` as arguments
         if k.startswith("VJ_"):
-          args_to_parse.append('--' + k[3:].lower().replace('_','-'))
-          args_to_parse.append(v)
+          if k == 'VJ_CMDLINE_FLAGS': # for setting bool flags like `--debug` or `--no-pretty`
+            for v in v.split(' '):
+              args_to_parse.append(v)
+          else:
+            args_to_parse.append('--' + k[3:].lower().replace('_','-'))
+            args_to_parse.append(v)
       for v in sys.argv[1:]:
         args_to_parse.append(v) # cmdline args can override one in env
 

--- a/vj4/util/options.py
+++ b/vj4/util/options.py
@@ -23,7 +23,7 @@ class Options(object):
     if self._dirty:
       args_to_parse = sys.argv[1:]
 
-      for k,v in os.environ.items(): # hack for using environments start with `VJ_` as arguments
+      for k,v in os.environ.items(): # using environments start with `VJ_` as arguments
         if k.startswith("VJ_"):
           args_to_parse.append(f"--{k[3:].lower().replace('_','-')}")
           args_to_parse.append(v) # append: use environments first


### PR DESCRIPTION
~~And why not accept arguments from both command-line and environment variables?~~

We can use environment variables to pass arguments now. For example, `python3 -m vj4.server --db-name vijos` equals `VJ_DB_NAME=vijos python3 -m vj4.server`.