### PR TITLE
Maximum version of sockjs that we support is 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=2.0.7,<3.0.0
 jinja2>=2.9.0
-sockjs>=0.6.0,<0.8.0
+sockjs>=0.6.0,<=0.7.0
 hoedown
 accept
 aioamqp


### PR DESCRIPTION
0.7.1 is incompatible but also in `sockjs>=0.6.0,<0.8.0`