### PR TITLE
Forward all smtp errors to user

### DIFF
--- a/vj4/service/mailer.py
+++ b/vj4/service/mailer.py
@@ -28,7 +28,7 @@ async def send_mail(to: str, subject: str, content: str):
       await server.ehlo()
       await server.login(options.smtp_user, options.smtp_password)
       await server.sendmail(options.mail_from, to, msg.as_string())
-  except aiosmtplib.errors.SMTPResponseException as e:
+  except aiosmtplib.errors.SMTPException as e:
     _logger.exception(e)
     raise error.SendMailError(to)
 


### PR DESCRIPTION
SMTP server can refuse to send mail and sendmain() throws `SMTPRecipientRefused`, which is not derived from `SMTPResponseException` but `SMTPException`. See also https://github.com/LukeXuan/aiosmtplib/blob/master/aiosmtplib/errors.py.

fixes #444