### PR TITLE
Fix discussion deletion

### DIFF
--- a/vj4/model/adaptor/discussion.py
+++ b/vj4/model/adaptor/discussion.py
@@ -158,11 +158,8 @@ async def edit(domain_id: str, did: document.convert_doc_id, **kwargs):
 
 @argmethod.wrap
 async def delete(domain_id: str, did: document.convert_doc_id):
-  # TODO(twd2): delete status?
+  # No need to delete related objects.
   await document.delete(domain_id, document.TYPE_DISCUSSION, did)
-  await document.delete_multi(domain_id, document.TYPE_DISCUSSION_REPLY,
-                              parent_doc_type=document.TYPE_DISCUSSION,
-                              parent_doc_id=did)
 
 
 @argmethod.wrap


### PR DESCRIPTION
No need to delete related objects.

Deletion is very dangerous. For security reasons, we do not allow the data to be actually *deleted*, and we just *move* it (to `oplog`). Main discussions are moved to `oplog` in handlers so they can be deleted here, but for related objects (e.g., replies), we have no oplogs (actually, no need to have, since they cannot be accessed once their main discussions are removed), so we should not delete them. This PR fixes this.

Please note that this is the same for training, contest, homework, and problem deletion (in the future).