### PR TITLE
fix username trim

### DIFF
--- a/vj4/ui/components/discussion/comments.page.js
+++ b/vj4/ui/components/discussion/comments.page.js
@@ -113,7 +113,7 @@ async function onCommentClickReplyReply(ev) {
   const $mediaBody = $evTarget.closest('.media__body');
   const username = $mediaBody
     .find('.user-profile-name').eq(0)
-    .text();
+    .text().trim();
 
   $evTarget
     .closest('.dczcomments__item')


### PR DESCRIPTION
This problem is introduced in https://github.com/vijos/vj4/pull/436/files#diff-b5363be31d0758673cf5734bf2647b79R12

Before:
![20200730200051](https://user-images.githubusercontent.com/3244435/88920901-32606580-d2a0-11ea-9695-c63a0901d802.png)

After:
![20200730200342](https://user-images.githubusercontent.com/3244435/88920903-342a2900-d2a0-11ea-86f5-625504338ea3.png)
