### PR TITLE
Fix url encoding.

### DIFF
--- a/vj4/handler/base.py
+++ b/vj4/handler/base.py
@@ -7,6 +7,7 @@ import logging
 import markupsafe
 import pytz
 import sockjs
+import urllib.parse
 from aiohttp import web
 from email import utils
 
@@ -367,7 +368,8 @@ def _get_csrf_token(session_id_binary):
 @functools.lru_cache()
 def _reverse_url(name, *, domain_id, **kwargs):
   """DEPRECATED: This function is deprecated. But we don't have a replacement yet."""
-  kwargs = {key: str(value) for key, value in kwargs.items()}
+  kwargs = {key: urllib.parse.quote(str(value), safe='')
+            for key, value in kwargs.items()}
   if domain_id != builtin.DOMAIN_ID_SYSTEM:
     name += '_with_domain_id'
     kwargs['domain_id'] = domain_id


### PR DESCRIPTION
The tag "输入/输出" in https://vijos.org/d/dreamerjack_oj/p/1001 currently links to https://vijos.org/d/dreamerjack_oj/p/category/%E8%BE%93%E5%85%A5/%E8%BE%93%E5%87%BA (404: Not Found) as the slash wasn't encoded.