### PR TITLE
Update version requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         ports:
           - "5672:5672"
       mongodb:
-        image: mongo
+        image: mongo:5.0
         ports:
           - "27017:27017"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     services:
       rabbitmq:
         image: rabbitmq

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There is pre-built docker package at `vijos/vj4`. This is maintained by [@moesoh
 
 #### Prerequisites
 
-* [Python 3.6+](https://www.python.org/downloads/)
+* [Python 3.7+, <=3.9](https://www.python.org/downloads/)
 * [MongoDB 3.0+, <=5.0](https://www.mongodb.com/docs/v5.0/installation/)
 * [Node.js 10.0+](https://nodejs.org/en/download/package-manager/)
 * [RabbitMQ](http://www.rabbitmq.com/)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There is pre-built docker package at `vijos/vj4`. This is maintained by [@moesoh
 #### Prerequisites
 
 * [Python 3.6+](https://www.python.org/downloads/)
-* [MongoDB 3.0+, <3.6](https://docs.mongodb.org/manual/installation/)
+* [MongoDB 3.0+, <=5.0](https://www.mongodb.com/docs/v5.0/installation/)
 * [Node.js 10.0+](https://nodejs.org/en/download/package-manager/)
 * [RabbitMQ](http://www.rabbitmq.com/)
 


### PR DESCRIPTION
- Legacy opcodes are supported till MongoDB 5.0.
  https://www.mongodb.com/docs/v6.0/legacy-opcodes/
- Python 3.6 is EOL